### PR TITLE
sgIP: fix latent signed-byte protocol parsing and recvfrom/ioctl issues on other platforms

### DIFF
--- a/source/sgIP/sgIP_DHCP.c
+++ b/source/sgIP/sgIP_DHCP.c
@@ -195,7 +195,7 @@ void sgIP_DHCP_Release() { // call to dump our DHCP address and leave.
 }
 int  sgIP_DHCP_Update() { // MUST be called periodicly; returns status - call until it returns SGIP_DHCP_STATUS_SUCCESS or _FAILED.
 	sgIP_DHCP_Packet * p;
-	struct sockaddr_in * sain;
+	struct sockaddr_in sain;
 	int i,j,n,l;
 	if(dhcp_status!=SGIP_DHCP_STATUS_WORKING) return dhcp_status;
 	int send = 0;
@@ -205,7 +205,10 @@ int  sgIP_DHCP_Update() { // MUST be called periodicly; returns status - call un
 
 		while(1) {
          socklen_t sainlen;
-			l=recvfrom(dhcp_socket,p,sizeof(sgIP_DHCP_Packet),0,(struct sockaddr *)&sain,&sainlen);
+			sainlen=sizeof(sain);
+			l=recvfrom(dhcp_socket,p,sizeof(sgIP_DHCP_Packet),0,
+			           (struct sockaddr *)&sain,
+			           &sainlen);
 			if(l==-1) break;
 			if(p->op!=2 || p->htype!=1 || p->hlen!=6 || p->xid!=dhcp_tid ) continue;
 			// check magic cookie

--- a/source/sgIP/sgIP_DHCP.h
+++ b/source/sgIP/sgIP_DHCP.h
@@ -48,7 +48,7 @@ typedef struct SGIP_DHCP_PACKET { // yes, freaking big endian prevails here too.
    unsigned char chaddr[16];  // client hardware address
    char sname[64];         // optional server hostname (null terminated string)
    char file[128];         // boot file name, null terminated string
-   char options[312];      // optional parameters
+   unsigned char options[312];      // optional parameters
 } sgIP_DHCP_Packet;
 
 enum SGIP_DHCP_STATUS {

--- a/source/sgIP/sgIP_DNS.c
+++ b/source/sgIP/sgIP_DNS.c
@@ -354,6 +354,7 @@ dns_listenonly:
 
          do {
             socklen_t sainlen;
+            sainlen=sizeof(sain);
             i=recvfrom(dns_sock,responsedata,512,0,(struct sockaddr *)&sain,&sainlen);
             if(i!=-1) break;
             dtime=sgIP_timems-query_time_start;

--- a/source/sgIP/sgIP_DNS.c
+++ b/source/sgIP/sgIP_DNS.c
@@ -284,15 +284,15 @@ int sgIP_DNS_genquery(const char * name) {
 }
 
 void sgIP_DNS_CopyAliasAt(char * deststr,int offset) {
-   char * c;
+   unsigned char * c;
    int i,j;
    i=0;
-   c=(char *)responsedata+offset;
+   c=responsedata+offset;
    do {
       j=c[0];
       if(j>63) {
          j=((j&63)<<8) | c[1];
-         c=(char *)responsedata+j;
+         c=responsedata+j;
          continue;
       }
       if(!j) break;

--- a/source/sgIP/sgIP_sockets.c
+++ b/source/sgIP/sgIP_sockets.c
@@ -397,6 +397,7 @@ int ioctl(int socket, int cmd, ...) {
 				retval=SGIP_ERROR(EINVAL);
 			}
 		}
+		break;
     default:
         retval = SGIP_ERROR(EINVAL);
 	}


### PR DESCRIPTION
Running sgIP on x86 uncovered these latent issues/UB that wouldn't normally show up on ARM/NDS, but still good to fix:

- `options[]` as a signed `char` uncovers three issues.. the `0x82` magic byte sign-extends to -126 so every DHCP reply gets rejected, `case 255` never gets matched (end of options) and `(options[i]<<24)` is UB on negative values
- use a value, not an uninitialized pointer for `recvfrom`
- `sgIP_DHCP_Update` passed in an uninitialized `sain`
- explicitly init the `sainlen` arg before `recvfrom`
- `sgIP_DNS_CopyAliasAt` fails the `j>63` test fail as a signed char
- `ioctl(FIONREAD)` (unused on NDS) accidentally fell through into `default:` and clobbered its successful result with `EINVAL`